### PR TITLE
Add gnome-console packages.x86_64

### DIFF
--- a/iso/packages.x86_64
+++ b/iso/packages.x86_64
@@ -164,6 +164,7 @@ gnome-characters
 gnome-clocks
 gnome-color-manager
 gnome-connections
+gnome-console
 gnome-control-center
 gnome-tweaks
 gnome-font-viewer


### PR DESCRIPTION
Isn't it better to have gnome-console in parch?